### PR TITLE
Fix bug with typo in conditions and fix knows bugs. README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ For deploying you need a list of permissions. For beginners might be difficult t
 
 ## Usage
 
+__IMPORTANT:__ *The last code from master might need to temporary enable the option `nat_enabled` (access to external resources) at the first initialization since, during the creation of the cluster, the instance needs to get a docker image. An alternative could be placing the cluster on a public subnet*
+
 The module can be deployed with almost default values of variables. For more details of the default values looking [here](#inputs)
 
 ```hcl
@@ -232,7 +234,7 @@ $ terraform destroy
 | docker\_repo | Vault Docker repository URI | `string` | `"docker://vault"` | no |
 | docker\_tag | Vault Docker image version tag | `string` | `"1.4.2"` | no |
 | internal\_zone | Name for internal domain zone. Need for assigning domain names <br>to each of nodes for cluster server-to-server communication.<br>Also used for SSH connection over Bastion host. | `string` | `"vault.int"` | no |
-| nat\_enabled | Determines to enable or disable creating NAT gateway and assigning <br>it to VPC Private Subnet. If you intend to use Vault only with <br>internal resources and internal network, you can disable this option <br>otherwise, you need to enable it. Allowing external routing might be <br>a potential security vulnerability. Also, enabling these options <br>will be additional money costs and not covered by the AWS Free Tier <br>program. | `bool` | `false` | no |
+| nat\_enabled | Determines to enable or disable creating NAT gateway and assigning <br>it to VPC Private Subnet. If you intend to use Vault only with <br>internal resources and internal network, you can disable this option <br>otherwise, you need to enable it. Allowing external routing might be <br>a potential security vulnerability. Also, enabling these options <br>will be additional money costs and not covered by the AWS Free Tier <br>program.<br>___ IMPORTANT:\_\_ since during the creation of the cluster, the <br>instance needs to get a docker image, then it is necessary to <br>enable `nat enabled` at the first initialization | `bool` | `false` | no |
 | node\_allow\_public | Assign public network to nodes (EC2 Instances). EC2 will be <br>available publicly with HTTPS "node\_port" ports and SSH "ssh\_port". <br>For debugging only, don't use on production! | `bool` | `false` | no |
 | node\_allowed\_subnets | If variable "node\_allow\_public" is set to "true" - list of these <br>IPs will be allowed to connect to Vault node directly (to instances) | `list(string)` | <pre>[<br>  "0.0.0.0/32"<br>]</pre> | no |
 | node\_cert\_hours\_valid | The number of hours after initial issuing that the certificate <br>will become invalid for Vault node. The certificate used for <br>internal communication in a cluster by peers and to connect from <br>ALB. Not recommended set a small value as there is no reissuance <br>mechanism without applying of the Terraform | `number` | `43800` | no |

--- a/ec2.tf
+++ b/ec2.tf
@@ -54,6 +54,11 @@ resource aws_instance "node" {
     volume_type           = var.node_volume_type
     delete_on_termination = true
   }
+
+  depends_on = [
+    aws_subnet.public,
+    aws_subnet.private,
+  ]
 }
 
 resource aws_ebs_volume "data" {

--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,9 @@ variable "nat_enabled" {
     a potential security vulnerability. Also, enabling these options 
     will be additional money costs and not covered by the AWS Free Tier 
     program.
+    ___ IMPORTANT:__ since during the creation of the cluster, the 
+    instance needs to get a docker image, then it is necessary to 
+    enable `nat enabled` at the first initialization
   EOT
   type        = bool
   default     = false

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,12 +1,12 @@
 locals {
-  public_subnets_list = (var.vpc_public_subnets != []
+  public_subnets_list = (length(var.vpc_public_subnets) != 0
     ? var.vpc_public_subnets
     : formatlist(
       var.vpc_public_subnet_tmpl,
       range(1, length(data.aws_availability_zones.current.names) + 1)
     )
   )
-  private_subnets_list = (var.vpc_private_subnets != []
+  private_subnets_list = (length(var.vpc_private_subnets) != 0
     ? var.vpc_private_subnets
     : formatlist(
       var.vpc_private_subnet_tmpl,

--- a/vpc.tf
+++ b/vpc.tf
@@ -55,7 +55,7 @@ resource aws_subnet "public" {
   vpc_id                  = aws_vpc.this.id
   cidr_block              = each.value.cidr_block
   availability_zone       = each.value.zone_name
-  map_public_ip_on_launch = false
+  map_public_ip_on_launch = true
 
   tags = merge(local.tags, {
     Name = format(local.name_tmpl,


### PR DESCRIPTION
- Fixed bug with typo in conditions for templating `public_subnets_list` and `private_subnets_list` in locals variables. Closes https://github.com/binlab/terraform-aws-vault-ha-raft/issues/33
- Add subnets to explicit dependencies for EC2
- Enable option `map_public_ip_on_launch for = true` for public subnet
- Add an important notice to README regarding access to external resources (docker hub in this case) in time of creating a cluster