### PR TITLE
Fix source of module for some examples

### DIFF
--- a/examples/basic-usage-quick-start/README.md
+++ b/examples/basic-usage-quick-start/README.md
@@ -48,7 +48,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vault"></a> [vault](#module\_vault) | github.com/binlab/terraform-aws-vault-ha-raft | v0.1.8 |
+| <a name="module_vault"></a> [vault](#module\_vault) | github.com/binlab/terraform-aws-vault-ha-raft | master |
 
 ## Resources
 

--- a/examples/basic-usage-quick-start/main.tf
+++ b/examples/basic-usage-quick-start/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 module "vault" {
-  source = "github.com/binlab/terraform-aws-vault-ha-raft?ref=v0.1.8"
+  source = "github.com/binlab/terraform-aws-vault-ha-raft?ref=master"
 
   # the name that will appear for all resources and tags associated with 
   # the cluster. Convenient to test multiple clusters in the same region

--- a/examples/development-debugging-sandbox/README.md
+++ b/examples/development-debugging-sandbox/README.md
@@ -72,7 +72,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_bastion"></a> [bastion](#module\_bastion) | github.com/binlab/terraform-aws-bastion | v0.1.5 |
-| <a name="module_vault"></a> [vault](#module\_vault) | github.com/binlab/terraform-aws-vault-ha-raft | master |
+| <a name="module_vault"></a> [vault](#module\_vault) | ../.. | n/a |
 
 ## Resources
 

--- a/examples/development-debugging-sandbox/main.tf
+++ b/examples/development-debugging-sandbox/main.tf
@@ -24,7 +24,7 @@ module "bastion" {
 
 
 module "vault" {
-  source = "github.com/binlab/terraform-aws-vault-ha-raft?ref=master"
+  source = "../.."
 
   cluster_name        = "vault-debug"
   cluster_count       = var.cluster_count


### PR DESCRIPTION
- Fixed source of module for `basic-usage-quick-start` example to latest `master` branch
- Replaced source of module for `development-debugging-sandbox` example for convenience development and debugging